### PR TITLE
feat: add X Lists support (show, tweets, members)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v2.4.0 (2026-02-09)
+
+### Added — X Lists Support
+Browse, pull tweets from, and inspect members of curated X Lists. Useful for daily digests, monitoring curated feeds, and research across a group of accounts.
+
+- **`lists show <username>`** — discover lists owned by a user
+- **`lists tweets <list_id>`** — pull recent tweets from a list with pagination, sorting, and dedup (same flags as search: `--pages`, `--limit`, `--sort`, `--json`)
+- **`lists members <list_id>`** — show list members with follower counts and bios
+- Aliases: `lists`/`list`/`l`, `tweets`/`t`, `members`/`m`
+- New API functions: `getOwnedLists`, `getListTweets`, `getListMembers`, `getUserId`
+- Typed interfaces: `XList`, `ListMember`
+- Formatters: `formatListsTelegram`, `formatListMembersTelegram`
+
 ## v2.3.0 (2026-02-09)
 
 ### Fixed — Remove LLM Hallucinations

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Wraps the X API into a fast CLI so your AI agent (or you) can search tweets, pul
 
 - **Search** with engagement sorting, time filtering, noise removal
 - **Quick mode** for cheap, targeted lookups
+- **Lists** — pull tweets from curated X Lists, browse members
 - **Watchlists** for monitoring accounts
 - **Cache** to avoid repeat API charges
 - **Cost transparency** — every search shows what it cost
@@ -50,6 +51,8 @@ git clone https://github.com/rohunvora/x-research-skill.git x-research
 - "Search X for OpenClaw skills"
 - "What's CT saying about BNKR today?"
 - "Check what @frankdegods posted recently"
+- "Pull today's tweets from my smart smart list"
+- "Who's on my X list?"
 
 ### CLI commands
 ```bash
@@ -66,6 +69,11 @@ bun run x-search.ts thread TWEET_ID
 
 # Single tweet
 bun run x-search.ts tweet TWEET_ID
+
+# Lists — browse and pull from curated X Lists
+bun run x-search.ts lists show <username>
+bun run x-search.ts lists tweets <list_id> --pages 3 --json
+bun run x-search.ts lists members <list_id>
 
 # Watchlist
 bun run x-search.ts watchlist add username "optional note"
@@ -143,6 +151,52 @@ Filters out low-engagement tweets (≥10 likes required). Applied post-fetch sin
 bun run x-search.ts search "crypto AI" --quality
 ```
 
+## Lists
+
+Pull tweets from curated X Lists — useful for monitoring a group of accounts without individual watchlist entries or search queries.
+
+### Commands
+
+```bash
+# Show all lists owned by a user
+bun run x-search.ts lists show <username>
+
+# Get recent tweets from a list (supports pagination)
+bun run x-search.ts lists tweets <list_id> [--pages N] [--limit N] [--sort likes|recent] [--json]
+
+# Show list members
+bun run x-search.ts lists members <list_id> [--json]
+```
+
+### Examples
+
+```bash
+# See what lists @tulipking has
+bun run x-search.ts lists show tulipking
+
+# Pull last 300 tweets from a list (3 pages × 100)
+bun run x-search.ts lists tweets 1991270610291298748 --pages 3 --json
+
+# Get top tweets from a list sorted by likes
+bun run x-search.ts lists tweets 1991270610291298748 --sort likes --limit 20
+
+# Check who's on a list
+bun run x-search.ts lists members 1991270610291298748
+```
+
+### Aliases
+
+- `lists` / `list` / `l` — all work
+- `tweets` / `t` — tweet subcommand
+- `members` / `m` — members subcommand
+
+### Notes
+
+- `lists show` requires a username (resolves to user ID internally)
+- Private lists are only visible with an authenticated user's own token
+- `lists tweets` supports the same `--sort`, `--limit`, `--pages`, and `--json` flags as search
+- Tweets from lists go through the same dedup and formatting pipeline as search results
+
 ## Cost
 
 As of February 2026, the X API uses **pay-per-use pricing** with prepaid credits. No subscriptions, no monthly caps. You buy credits in the [Developer Console](https://console.x.com) and they're deducted per request.
@@ -162,6 +216,9 @@ As of February 2026, the X API uses **pay-per-use pricing** with prepaid credits
 | Standard search (1 page) | ~$0.50 |
 | Deep research (3 pages) | ~$1.50 |
 | Profile check (user + posts) | ~$0.51 |
+| List tweets (1 page, ≤100 posts) | ~$0.50 |
+| List tweets (3 pages) | ~$1.50 |
+| List members | ~$1.00 |
 | Watchlist check (5 accounts) | ~$2.55 |
 | Cached repeat (any) | free |
 
@@ -186,7 +243,7 @@ x-research/
 ├── SKILL.md              # Agent instructions (Claude reads this)
 ├── x-search.ts           # CLI entry point
 ├── lib/
-│   ├── api.ts            # X API wrapper
+│   ├── api.ts            # X API wrapper (search, threads, profiles, lists)
 │   ├── cache.ts          # File-based cache
 │   └── format.ts         # Telegram + markdown formatters
 └── data/

--- a/SKILL.md
+++ b/SKILL.md
@@ -83,6 +83,16 @@ Fetches full conversation thread by root tweet ID.
 bun run x-search.ts tweet <tweet_id> [--json]
 ```
 
+### Lists
+
+```bash
+bun run x-search.ts lists show <username>            # Show owned lists
+bun run x-search.ts lists tweets <list_id> [--pages N] [--limit N] [--sort likes|recent] [--json]
+bun run x-search.ts lists members <list_id> [--json]
+```
+
+Pull tweets from curated X Lists — useful for daily digests from a curated group of accounts. Supports same `--sort`, `--limit`, `--pages`, and `--json` flags as search. Aliases: `lists`/`list`/`l`, `tweets`/`t`, `members`/`m`.
+
 ### Watchlist
 
 ```bash
@@ -179,7 +189,7 @@ skills/x-research/
 ├── SKILL.md           (this file)
 ├── x-search.ts        (CLI entry point)
 ├── lib/
-│   ├── api.ts         (X API wrapper: search, thread, profile, tweet)
+│   ├── api.ts         (X API wrapper: search, thread, profile, tweet, lists)
 │   ├── cache.ts       (file-based cache, 15min TTL)
 │   └── format.ts      (Telegram + markdown formatters)
 ├── data/

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -138,6 +138,34 @@ export function formatResearchMarkdown(
 }
 
 /**
+ * Format a list of X Lists for display.
+ */
+export function formatListsTelegram(lists: any[]): string {
+  if (lists.length === 0) return "No lists found.";
+  let out = `📋 Your Lists (${lists.length})\n\n`;
+  for (const l of lists) {
+    const priv = l.private ? " 🔒" : "";
+    const desc = l.description ? ` — ${l.description.slice(0, 80)}` : "";
+    out += `  ${l.name}${priv} (${l.member_count || 0} members, id:${l.id})${desc}\n`;
+  }
+  return out;
+}
+
+/**
+ * Format list members for display.
+ */
+export function formatListMembersTelegram(listName: string, members: import("./api").ListMember[]): string {
+  if (members.length === 0) return `No members in ${listName}.`;
+  let out = `👥 ${listName} — ${members.length} members\n\n`;
+  for (const m of members) {
+    const followers = m.public_metrics?.followers_count || 0;
+    const desc = m.description ? ` — ${m.description.slice(0, 60)}` : "";
+    out += `  @${m.username} (${compactNumber(followers)} followers)${desc}\n`;
+  }
+  return out;
+}
+
+/**
  * Format a user profile for Telegram.
  */
 export function formatProfileTelegram(user: any, tweets: Tweet[]): string {


### PR DESCRIPTION
## What

Adds support for browsing and pulling tweets from curated X Lists — three new subcommands under `lists`.

## Commands

- `lists show <username>` — discover lists owned by a user
- `lists tweets <list_id>` — pull recent tweets with pagination, sorting, and dedup
- `lists members <list_id>` — show list members with follower counts and bios

## Why

Lists are a natural research primitive — curated feeds of accounts grouped by topic. Useful for daily digests, monitoring a sector, or pulling signal from a trusted group without writing individual search queries or watchlist entries.

## Implementation

- **4 new API functions** in `lib/api.ts`: `getOwnedLists`, `getListTweets`, `getListMembers`, `getUserId`
- **2 typed interfaces**: `XList`, `ListMember` (no untyped `any[]` returns)
- **2 formatters** in `lib/format.ts`: `formatListsTelegram`, `formatListMembersTelegram`
- **CLI handler** in `x-search.ts`: `cmdLists()` with aliases (`lists`/`list`/`l`, `tweets`/`t`, `members`/`m`)
- Reuses existing infrastructure: `parseTweets`, `FIELDS`, `apiGet`, `sortBy`, `dedupe`, `--json` flag
- `lists tweets` supports same flags as search: `--pages`, `--limit`, `--sort`, `--json`

## Docs

- README: feature list, CLI examples, dedicated Lists section, cost table, file structure
- SKILL.md: CLI reference updated
- CHANGELOG: v2.4.0 entry

## Cost

Same pay-per-use pricing as other endpoints (~$0.50/page for tweets, ~$1.00 for member lookup).